### PR TITLE
👍 load external scripts as ESModules

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Execute D3.js</title>
-    <script src="https://cdn.jsdelivr.net/npm/htm@3.1.1/preact/standalone.umd.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js"></script>
-    <script src="./index.js"></script>
+    <script src="./index.js" type="module"></script>
   </head>
   <body></body>
 </html>

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@
 /// <reference lib="esnext" />
 /// <reference lib="dom" />
 
+import htm from "https://cdn.jsdelivr.net/npm/htm@3.1.1/+esm";
+import * as Preact from "https://cdn.jsdelivr.net/npm/preact@10.12.0/+esm";
+import * as Hooks from "https://cdn.jsdelivr.net/npm/preact@10.12.0/hooks/+esm";
+import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7.8.2/+esm";
+globalThis.htmPreact = { html: htm.bind(Preact.h), ...Preact, ...Hooks };
+globalThis.d3 = d3;
+
 /** @param {string} url
  * @return {Promise<void>}
  */
@@ -48,8 +55,6 @@ const loadAllStyles = async (urls) => {
   }
 };
 
-globalThis.addEventListener("load", () => {
-  const params = new URLSearchParams(location.search);
-  loadAllScripts(params.getAll("js"));
-  loadAllStyles(params.getAll("css"));
-});
+const params = new URLSearchParams(location.search);
+loadAllScripts(params.getAll("js"));
+loadAllStyles(params.getAll("css"));


### PR DESCRIPTION
close [⬜外部ライブラリ読み込みとindex.jsをesmにする](https://scrapbox.io/takker/⬜外部ライブラリ読み込みとindex.jsをesmにする)